### PR TITLE
style: 金種グリッドを画面幅に追従

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -57,10 +57,9 @@ header {
   justify-content: space-between;
   align-items: center;
   text-align: center;
-  margin: 10px auto;
+  margin: clamp(8px, 1.2vw, 16px) auto;
   width: 100%;
-  max-width: 500px;
-  padding: 0;
+  padding: 0 clamp(8px, 1.5vw, 24px);
   color: var(--text-primary);
   flex-shrink: 0;
   white-space: nowrap;
@@ -74,11 +73,10 @@ header {
 .container {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: var(--space-md);
-  padding: 0 4px 8px;
+  align-items: stretch;
+  gap: clamp(8px, 1.2vw, 16px);
+  padding: 0 clamp(8px, 1.5vw, 24px) clamp(12px, 2vw, 24px);
   width: 100%;
-  max-width: 500px;
   margin: 0 auto;
   flex: 1;
   min-height: 0;
@@ -97,9 +95,8 @@ header {
 .bills,
 .coins {
   display: grid;
-  gap: 10px;
+  gap: clamp(6px, 1vw, 14px);
   width: 100%;
-  max-width: 500px;
 }
 
 .bills.hidden,
@@ -124,18 +121,6 @@ header {
     --space-lg: 16px;
   }
 
-  .summary {
-    margin: 10px auto;
-  }
-
-  .container {
-    gap: 8px;
-  }
-
-  .bills,
-  .coins {
-    gap: 8px;
-  }
 }
 
 /* その他: 横向き (Landscape Mobile) */
@@ -144,7 +129,5 @@ header {
     padding: 5px 10px;
   }
 
-  .summary {
-    margin: 5px auto 10px auto;
-  }
+  .summary { margin: 5px auto 8px; }
 }

--- a/css/pc.css
+++ b/css/pc.css
@@ -145,12 +145,12 @@
     /* グリッド最適化 (PC) */
     .bills {
         grid-template-columns: repeat(2, 1fr) !important;
-        gap: 16px !important;
+        gap: clamp(10px, 1.2vw, 16px) !important;
     }
 
     .coins {
         grid-template-columns: repeat(3, 1fr) !important;
-        gap: 16px !important;
+        gap: clamp(10px, 1.2vw, 16px) !important;
     }
 }
 


### PR DESCRIPTION
金種グリッドとサマリーの最大幅を撤廃し、余白とグリッド間隔をclamp()で画面幅に応じて連続的に調整します。紙幣2列・硬貨3列は維持します。