### PR TITLE
style: モバイル金種画面を7行グリッド化

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -131,3 +131,64 @@ header {
 
   .summary { margin: 5px auto 8px; }
 }
+
+/* 縦向きモバイル: ヘッダー、サマリー、金種4行、ナビで画面高を配分 */
+@media (max-width: 1023px) and (orientation: portrait) {
+  .main-content {
+    display: grid;
+    grid-template-rows: 0.8fr 0.55fr repeat(4, minmax(0, 1fr)) 0.9fr;
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  header {
+    grid-row: 1;
+  }
+
+  .summary {
+    grid-row: 2;
+    margin: 0;
+    align-self: stretch;
+  }
+
+  .container {
+    grid-row: 3 / span 4;
+    display: grid;
+    grid-template-rows: repeat(4, minmax(0, 1fr));
+    gap: clamp(6px, 1vw, 10px);
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .bills,
+  .coins {
+    grid-row: span 2;
+    grid-template-rows: repeat(2, minmax(0, 1fr));
+    min-height: 0;
+  }
+
+  .bills.cny-cells {
+    grid-row: span 3;
+    grid-template-rows: repeat(3, minmax(0, 1fr));
+  }
+
+  .coins.cny-cells {
+    grid-row: span 1;
+    grid-template-rows: minmax(0, 1fr);
+  }
+
+  .cell {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-height: 0;
+  }
+
+  .bottom-nav {
+    grid-row: 7;
+    position: static;
+    height: auto;
+    min-height: 60px;
+  }
+}


### PR DESCRIPTION
縦向きスマホをヘッダー、サマリー、金種4行、下部ナビの7行グリッドで構成します。金種4行へ画面高を均等配分し、JPYとCNYの金種行数の違いにも対応します。