### PR TITLE
fix: モバイル下部ナビと文字階層を反映

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -156,6 +156,15 @@ button:active {
   color: var(--nav-item-active);
 }
 
+@media (max-width: 1023px) and (orientation: portrait) {
+  .bottom-nav {
+    align-self: stretch;
+    height: 100%;
+    min-height: 60px;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}
+
 /* --- リストアイテム (ノート・履歴) --- */
 .note-list,
 .history-list {

--- a/css/layout.css
+++ b/css/layout.css
@@ -193,9 +193,5 @@ header {
   .bottom-nav {
     grid-row: 7;
     position: static;
-    align-self: stretch;
-    height: 100%;
-    min-height: 60px;
-    padding-bottom: env(safe-area-inset-bottom);
   }
 }

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=5.0, user-scalable=yes, viewport-fit=cover"
     />
     <title>金種入力アプリ</title>
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style.css?v=20260830.1" />
     <!-- ファビコン -->
     <link rel="icon" type="image/x-icon" href="/favicon_io/favicon.ico" />
     <link

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@
 @import url('css/effects.css');
 @import url('css/layout.css');
 @import url('css/components.css');
+@import url('css/typography.css');
 @import url('css/modals.css');
 @import url('css/pc.css');
 


### PR DESCRIPTION
## 内容\n- モバイル縦画面で下部ナビが7行目を最後まで占めるよう、CSSの上書き順を整理\n- 未読込だった typography.css を読み込み、金額・金種・入力値の階層を有効化\n- style.css のキャッシュバスターを追加\n\n## 確認\n- git diff --check\n- 390×844の7行グリッドで、従来の下部余白の原因（60pxへの上書き）が解消するCSSカスケードを確認\n\n## 影響範囲\n- CSS読み込み順とモバイル下部ナビのサイズのみ。機能変更なし。