### PR TITLE
fix: GitHub Pagesのファビコン参照を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,34 +9,34 @@
     <title>金種入力アプリ</title>
     <link rel="stylesheet" href="style.css?v=20260830.3" />
     <!-- ファビコン -->
-    <link rel="icon" type="image/x-icon" href="/favicon_io/favicon.ico" />
+    <link rel="icon" type="image/x-icon" href="favicon_io/favicon.ico" />
     <link
       rel="icon"
       type="image/png"
       sizes="16x16"
-      href="/favicon_io/favicon-16x16.png"
+      href="favicon_io/favicon-16x16.png"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="32x32"
-      href="/favicon_io/favicon-32x32.png"
+      href="favicon_io/favicon-32x32.png"
     />
     <link
       rel="apple-touch-icon"
       sizes="180x180"
-      href="/favicon_io/apple-icon-180x180.png"
+      href="favicon_io/apple-icon-180x180.png"
     />
     <link
       rel="apple-touch-icon"
       sizes="152x152"
-      href="/favicon_io/apple-icon-152x152.png"
+      href="favicon_io/apple-icon-152x152.png"
     />
     <link
       rel="icon"
       type="image/png"
       sizes="192x192"
-      href="/favicon_io/android-icon-192x192.png"
+      href="favicon_io/android-icon-192x192.png"
     />
     <link rel="manifest" href="/kinshu-site/manifest.json" />
     <link


### PR DESCRIPTION
## 内容\n- ルート絶対パスになっていたfavicon・Apple Touch Iconの6参照を相対パスへ変更\n- GitHub Pagesのプロジェクト配下（/kinshu-site/）で正しく解決されるよう修正\n\n## 確認\n- 修正前: https://ineko0402.github.io/favicon_io/favicon.ico は404\n- 正しい配置先: https://ineko0402.github.io/kinshu-site/favicon_io/favicon.ico は200\n- git diff --check\n\n## 影響範囲\n- アイコンURLのみ。manifest.jsonは既に正しいパスです。