### PR TITLE
fix: モバイルヘッダーの通貨表記を短縮

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -16,7 +16,7 @@ import {
   renderSidebarNoteList,
   openNoteSwitchModal,
   openNoteCreateModal,
-} from "./ui/noteUI.js";
+} from "./ui/noteUI.js?v=20260830.4";
 import {
   renderSidebarHistoryList,
   openSavePointModal,

--- a/app/ui/noteUI.js
+++ b/app/ui/noteUI.js
@@ -40,7 +40,8 @@ export function updateNoteDisplay() {
   );
   const noteNameEl = document.getElementById("currentNoteName");
   if (noteNameEl && currentNote) {
-    noteNameEl.textContent = `${currentNote.name} (${currentNote.currency})`;
+    const currencyLabel = currentNote.currency === "JPY" ? "円" : "元";
+    noteNameEl.textContent = `${currentNote.name} · ${currencyLabel}`;
   }
 
   // PC用の表示も更新

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
               <span id="pc-currentNoteName">新規ノート 1 (JPY)</span>
             </div>
             <button id="noteSwitchBtn" class="header-button mobile-only">
-              <span id="currentNoteName">新規ノート 1 (JPY)</span> ▼
+              <span id="currentNoteName">新規ノート 1 · 円</span> ▼
             </button>
           </div>
           <div class="header-center">
@@ -338,7 +338,7 @@
     </div>
 
     <script type="module">
-      import "./app/main.js?v=20260830.3";
+      import "./app/main.js?v=20260830.4";
     </script>
 
     <!-- settingsTemplate (グローバル設定 - ダークモードのみ) -->


### PR DESCRIPTION
## 内容\n- モバイルのメインヘッダーを ノート名 · 円／元 表記へ短縮\n- PCヘッダーとノート切替メニューの JPY／CNY 表記は維持\n- 変更したモジュールのキャッシュ用版番号を更新\n\n## 確認\n- git diff --check\n- ノート切替メニューの表示は ${note.name} () のまま\n- PC用ノート名は ${currentNote.name} () のまま\n\n## 影響範囲\n- モバイルメインヘッダーの通貨表示のみ。ノートデータ・通貨の内部値は変更しません。